### PR TITLE
Move easyopencv dependency

### DIFF
--- a/olympia-v1.0.0/TeamCode/build.gradle
+++ b/olympia-v1.0.0/TeamCode/build.gradle
@@ -28,3 +28,6 @@ android {
         targetCompatibility 1.8
     }
 }
+dependencies {
+    implementation 'org.openftc:easyopencv:1.5.1'
+}

--- a/olympia-v1.0.0/build.gradle
+++ b/olympia-v1.0.0/build.gradle
@@ -21,6 +21,3 @@ allprojects {
         jcenter()
     }
 }
-dependencies {
-    implementation 'org.openftc:easyopencv:1.5.1'
-}


### PR DESCRIPTION
Move the easyopencv gradle dependency from the master build.gradle into the TeamCode one. For some reason, this is required for it to build properly.